### PR TITLE
Update CODEOWNERS to octo-developer-experience team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# Add a team or username to this file
-# Example:
-# *   @ministryofjustice/github-community
+*   @ministryofjustice/octo-developer-experience


### PR DESCRIPTION
## Summary
Updates the CODEOWNERS file to assign the @ministryofjustice/octo-developer-experience team as the default code owners for all files in this repository.

## Changes
- Set `* @ministryofjustice/octo-developer-experience` as the default code owner pattern
- This ensures all pull requests will automatically request review from the octo-developer-experience team

## Impact
- All future PRs will require review from @ministryofjustice/octo-developer-experience 