### PR TITLE
Weekly Workflow to Track Dependabot Upgrades Across DevEx Repositories

### DIFF
--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -37,14 +37,12 @@ jobs:
 
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ steps.target.outputs.owner }}
           repositories: ${{ steps.target.outputs.name }}
-          permission-issues: write
-          permission-pull-requests: read
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -39,8 +39,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
-          private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ steps.target.outputs.owner }}
           repositories: ${{ steps.target.outputs.name }}
           permission-issues: write

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -1,0 +1,155 @@
+name: Create or Update Dependabot Tracking Issue
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        description: "Repository to process in owner/name format"
+        required: true
+        type: string
+    secrets:
+      APP_ID:
+        description: "GitHub App ID"
+        required: true
+      APP_PRIVATE_KEY:
+        description: "GitHub App private key"
+        required: true
+
+jobs:
+  process-repo:
+    name: Process ${{ inputs.repo }}
+    runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+      - name: Parse target repo
+        id: target
+        env:
+          TARGET_REPO: ${{ inputs.repo }}
+        run: |
+          set -euo pipefail
+
+          owner="${TARGET_REPO%%/*}"
+          name="${TARGET_REPO##*/}"
+
+          echo "owner=$owner" >> "$GITHUB_OUTPUT"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ steps.target.outputs.owner }}
+          repositories: ${{ steps.target.outputs.name }}
+          permission-issues: write
+          permission-pull-requests: read
+
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Process current repo
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ inputs.repo }}
+        run: |
+          set -euo pipefail
+
+          REPO_NAME=${REPO##*/}
+          ISSUE_TITLE="Dependabot PRs for $REPO_NAME"
+
+          echo
+          echo "=== Processing $REPO_NAME ==="
+
+          PR_LIST=$(gh pr list \
+            --repo "$REPO" \
+            --base main \
+            --state open \
+            --json number,title,headRefName,author,labels \
+            --search "label:dependencies")
+
+          PR_LIST=$(echo "$PR_LIST" | jq '[.[] | select(
+            (.author.login | test("dependabot|app/dependabot"; "i")) or
+            (.labels[]?.name | test("dependency"; "i"))
+          )]')
+
+          echo "PRs found for $REPO_NAME:"
+          if [[ $(echo "$PR_LIST" | jq 'length') -eq 0 ]]; then
+            echo "  (none)"
+            exit 0
+          fi
+
+          echo "$PR_LIST" | jq -r '.[] | "  - #\(.number): \(.title) (branch \(.headRefName), author \(.author.login))"'
+
+          PR_DESCRIPTION=$(echo "$PR_LIST" \
+            | jq -r \
+              --arg repo "$REPO" \
+              '.[] | "PR Number: \(.number)\nTitle: \(.title)\nBranch: \(.headRefName)\nURL: https://github.com/\($repo)/pull/\(.number)\n"')
+
+          ISSUE_BODY=$(jq -n --arg repo "$REPO_NAME" --arg desc "$PR_DESCRIPTION" \
+            -r '"Repository: \($repo)\n\n\($desc)"')
+
+          EXISTING_ISSUE=$(gh issue list \
+            --repo "$REPO" \
+            --state open \
+            --limit 100 \
+            --json number,title,url \
+            | jq -c --arg title "$ISSUE_TITLE" 'map(select(.title == $title)) | .[0] // empty')
+
+          if [[ -z "$EXISTING_ISSUE" ]]; then
+            echo "Creating GitHub issue for $REPO_NAME"
+            PAYLOAD=$(jq -n --arg title "$ISSUE_TITLE" --arg body "$ISSUE_BODY" \
+              '{ title: $title, body: $body }')
+
+            CREATE=$(printf '%s' "$PAYLOAD" | gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              "repos/$REPO/issues" \
+              --input -)
+
+            ISSUE_NUMBER=$(echo "$CREATE" | jq -r '.number // empty')
+            ISSUE_URL=$(echo "$CREATE" | jq -r '.html_url // empty')
+          else
+            ISSUE_NUMBER=$(echo "$EXISTING_ISSUE" | jq -r '.number')
+            ISSUE_URL=$(echo "$EXISTING_ISSUE" | jq -r '.url')
+
+            echo "Updating GitHub issue #$ISSUE_NUMBER"
+            NOW=$(date '+%Y-%m-%d %H:%M:%S')
+            UPDATE_PAYLOAD=$(jq -n --arg title "$ISSUE_TITLE" --arg repo "$REPO_NAME" --arg now "$NOW" --arg desc "$PR_DESCRIPTION" \
+              '{ title: $title, body: "Updated on \($now)\nRepository: \($repo)\n\n\($desc)" }')
+
+            printf '%s' "$UPDATE_PAYLOAD" | gh api \
+              --method PATCH \
+              -H "Accept: application/vnd.github+json" \
+              "repos/$REPO/issues/$ISSUE_NUMBER" \
+              --input - >/dev/null
+          fi
+
+          if [[ -z "$ISSUE_NUMBER" || -z "$ISSUE_URL" ]]; then
+            echo "ERROR: issue reference is empty after create/update; aborting."
+            exit 1
+          fi
+
+          echo "GitHub issue: #$ISSUE_NUMBER"
+          TRACKING_COMMENT="Tracked in #$ISSUE_NUMBER ($ISSUE_URL)"
+
+          for NUM in $(echo "$PR_LIST" | jq -r '.[].number'); do
+            COMMENT_EXISTS=$(
+              gh api --paginate "repos/$REPO/issues/$NUM/comments?per_page=100" \
+                | jq -s --arg body "$TRACKING_COMMENT" 'flatten | any(.body == $body)'
+            )
+
+            if [[ "$COMMENT_EXISTS" == "true" ]]; then
+              echo "Tracking comment already exists on PR #$NUM"
+              continue
+            fi
+
+            echo "Adding tracking comment to PR #$NUM"
+            gh api \
+              --method POST \
+              "repos/$REPO/issues/$NUM/comments" \
+              -f body="$TRACKING_COMMENT" >/dev/null
+          done

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -39,8 +39,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
+          private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ steps.target.outputs.owner }}
           repositories: ${{ steps.target.outputs.name }}
           permission-issues: write

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,8 @@ jobs:
     permissions:
       contents: read
     env:
-      ACTIONLINT_VERSION: 1.7.7
-      ACTIONLINT_LINUX_AMD64_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+      ACTIONLINT_VERSION: 1.7.12
+      ACTIONLINT_LINUX_AMD64_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -1,0 +1,97 @@
+name: Run Dependabot PR Tracker
+
+on:
+  schedule:
+    - cron: "25 9 * * 5"
+      timezone: "Europe/London"
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/dependabot-pr-tracker.yml
+      - .github/workflows/run-dependabot-pr-tracker.yml
+
+jobs:
+  biweekly-gate:
+    name: Check biweekly schedule
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - name: Decide whether this is an active Friday
+        id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TZ: Europe/London
+          ANCHOR_FRIDAY: "2026-05-08"
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" != "schedule" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TODAY=$(date +%F)
+          DELTA_SECONDS=$(( $(date -d "$TODAY" +%s) - $(date -d "$ANCHOR_FRIDAY" +%s) ))
+          DELTA_WEEKS=$(( DELTA_SECONDS / 604800 ))
+
+          if (( DELTA_WEEKS % 2 == 0 )); then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  discover-repos:
+    name: Discover team repositories
+    needs: biweekly-gate
+    if: needs.biweekly-gate.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      TEAM_ORG: ministryofjustice
+      TEAM_SLUG: octo-developer-experience
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    steps:
+      - name: Create GitHub App token for team discovery
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ env.TEAM_ORG }}
+          permission-members: read
+
+      - name: Build repository matrix
+        id: build-matrix
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CURRENT_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          matrix_json=$(
+            gh api --paginate "orgs/$TEAM_ORG/teams/$TEAM_SLUG/repos?per_page=100" \
+              | jq -cs --arg current "$CURRENT_REPO" '
+                  {
+                    repo: (([.[][] | .full_name] + [$current]) | unique)
+                  }
+                '
+          )
+
+          echo "matrix=$matrix_json" >> "$GITHUB_OUTPUT"
+
+  run-tracker:
+    name: Run tracker for ${{ matrix.repo }}
+    needs: discover-repos
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover-repos.outputs.matrix) }}
+    permissions: {}
+    uses: ./.github/workflows/dependabot-pr-tracker.yml
+    with:
+      repo: ${{ matrix.repo }}
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -58,8 +58,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
+          private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ env.TEAM_ORG }}
           permission-members: read
 
@@ -93,5 +93,5 @@ jobs:
     with:
       repo: ${{ matrix.repo }}
     secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_ID: ${{ secrets.REPO_ISSUE_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -60,6 +60,7 @@ jobs:
           app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ env.TEAM_ORG }}
+          repositories: ${{ github.event.repository.name }}
 
       - name: Build repository matrix
         id: build-matrix

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -3,7 +3,6 @@ name: Run Dependabot PR Tracker
 on:
   schedule:
     - cron: "25 9 * * 5"
-      timezone: "Europe/London"
   workflow_dispatch:
   pull_request:
     branches: [main]
@@ -56,12 +55,11 @@ jobs:
     steps:
       - name: Create GitHub App token for team discovery
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         with:
           app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ env.TEAM_ORG }}
-          permission-members: read
 
       - name: Build repository matrix
         id: build-matrix


### PR DESCRIPTION
This pull request introduces a new automated workflow for tracking open Dependabot pull requests across all team repositories, and provides a scheduled, biweekly mechanism to manage and update tracking issues. The key changes include the addition of two new GitHub Actions workflow files: one for processing and updating tracking issues per repository, and another for orchestrating the workflow across all team repositories on a biweekly schedule.

**New Dependabot PR tracking automation:**

* Added `.github/workflows/dependabot-pr-tracker.yml` to create or update a tracking issue in each repository, listing all open Dependabot PRs and adding tracking comments to those PRs.
* Added `.github/workflows/run-dependabot-pr-tracker.yml` to:
  * Schedule the tracker to run every other Friday (biweekly) using a gate based on an anchor date.
  * Discover all repositories for the `octo-developer-experience` team in the `ministryofjustice` organization.
  * Run the tracking workflow for each discovered repository and the current repository.