### PR TITLE
327 document dependabot process

### DIFF
--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -37,12 +37,15 @@ jobs:
 
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@v3 #todo sha pin
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ steps.target.outputs.owner }}
           repositories: ${{ steps.target.outputs.name }}
+          permission-issues: write
+          permission-organization-projects: write
+          permission-pull-requests: read
 
       - name: Install prerequisites
         run: |
@@ -58,6 +61,21 @@ jobs:
 
           REPO_NAME=${REPO##*/}
           ISSUE_TITLE="Dependabot PRs for $REPO_NAME"
+
+          case "$REPO_NAME" in
+            developer-experience-documentation|ministry-of-justice-developer-portal|ministry-of-justice-tech-radar|octo-access)
+              TEAM_VALUE="👾 Engineering Portal"
+              ;;
+            ministry-of-justice-engineering-platform|ministry-of-justice-github-analysis|moj-github-discovery)
+              TEAM_VALUE="🔧 Engineering Platform"
+              ;;
+            *)
+              TEAM_VALUE="🔧 Engineering Platform"
+              ;;
+          esac
+
+          PROJECT_OWNER="ministryofjustice"
+          PROJECT_TITLE="👩‍💻 Developer Experience Team"
 
           echo
           echo "=== Processing $REPO_NAME ==="
@@ -94,7 +112,7 @@ jobs:
             --repo "$REPO" \
             --state open \
             --limit 100 \
-            --json number,title,url \
+            --json id,number,title,url \
             | jq -c --arg title "$ISSUE_TITLE" 'map(select(.title == $title)) | .[0] // empty')
 
           if [[ -z "$EXISTING_ISSUE" ]]; then
@@ -110,9 +128,11 @@ jobs:
 
             ISSUE_NUMBER=$(echo "$CREATE" | jq -r '.number // empty')
             ISSUE_URL=$(echo "$CREATE" | jq -r '.html_url // empty')
+            ISSUE_NODE_ID=$(echo "$CREATE" | jq -r '.node_id // empty')
           else
             ISSUE_NUMBER=$(echo "$EXISTING_ISSUE" | jq -r '.number')
             ISSUE_URL=$(echo "$EXISTING_ISSUE" | jq -r '.url')
+            ISSUE_NODE_ID=$(echo "$EXISTING_ISSUE" | jq -r '.id // empty')
 
             echo "Updating GitHub issue #$ISSUE_NUMBER"
             NOW=$(date '+%Y-%m-%d %H:%M:%S')
@@ -126,10 +146,83 @@ jobs:
               --input - >/dev/null
           fi
 
-          if [[ -z "$ISSUE_NUMBER" || -z "$ISSUE_URL" ]]; then
+          if [[ -z "$ISSUE_NUMBER" || -z "$ISSUE_URL" || -z "$ISSUE_NODE_ID" ]]; then
             echo "ERROR: issue reference is empty after create/update; aborting."
             exit 1
           fi
+
+          PROJECT_DATA=$(gh api graphql -f query='query($owner:String!, $title:String!) { organization(login:$owner) { projectsV2(first: 20, query: $title) { nodes { id title fields(first: 50) { nodes { __typename ... on ProjectV2Field { id name } ... on ProjectV2SingleSelectField { id name options { id name } } ... on ProjectV2IterationField { id name configuration { iterations { id title startDate } } } } } } } } }' -f owner="$PROJECT_OWNER" -f title="$PROJECT_TITLE")
+
+          PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r --arg title "$PROJECT_TITLE" '.data.organization.projectsV2.nodes[] | select(.title == $title) | .id' | head -n1)
+          if [[ -z "$PROJECT_ID" ]]; then
+            echo "ERROR: project '$PROJECT_TITLE' not found under organization '$PROJECT_OWNER'."
+            exit 1
+          fi
+
+          PROJECT_ITEM_ID=$(gh api graphql -f query='query($issueId:ID!, $projectId:ID!) { node(id:$issueId) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }' -f issueId="$ISSUE_NODE_ID" -f projectId="$PROJECT_ID" | jq -r --arg project "$PROJECT_ID" '.data.node.projectItems.nodes[]? | select(.project.id == $project) | .id' | head -n1)
+
+          if [[ -z "$PROJECT_ITEM_ID" ]]; then
+            PROJECT_ITEM_ID=$(gh api graphql -f query='mutation($projectId:ID!, $contentId:ID!) { addProjectV2ItemById(input:{ projectId:$projectId, contentId:$contentId }) { item { id } } }' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_NODE_ID" | jq -r '.data.addProjectV2ItemById.item.id // empty')
+          fi
+
+          if [[ -z "$PROJECT_ITEM_ID" ]]; then
+            echo "ERROR: failed to add/fetch issue project item for project '$PROJECT_TITLE'."
+            exit 1
+          fi
+
+          get_field_id() {
+            local field_name="$1"
+            echo "$PROJECT_DATA" | jq -r --arg name "$field_name" '.data.organization.projectsV2.nodes[].fields.nodes[]? | select(.name == $name) | .id // empty' | head -n1
+          }
+
+          get_single_select_option_id() {
+            local field_name="$1"
+            local option_name="$2"
+            echo "$PROJECT_DATA" | jq -r --arg field "$field_name" --arg option "$option_name" '.data.organization.projectsV2.nodes[].fields.nodes[]? | select(.name == $field) | .options[]? | select(.name == $option) | .id // empty' | head -n1
+          }
+
+          set_single_select_field() {
+            local field_name="$1"
+            local option_value="$2"
+
+            local field_id
+            field_id=$(get_field_id "$field_name")
+            if [[ -z "$field_id" ]]; then
+              echo "ERROR: project field '$field_name' not found."
+              exit 1
+            fi
+
+            local option_id
+            option_id=$(get_single_select_option_id "$field_name" "$option_value")
+            if [[ -z "$option_id" ]]; then
+              echo "ERROR: option '$option_value' not found for field '$field_name'."
+              exit 1
+            fi
+
+            gh api graphql -f query='mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!) { updateProjectV2ItemFieldValue(input: { projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{ singleSelectOptionId:$optionId } }) { projectV2Item { id } } }' -f projectId="$PROJECT_ID" -f itemId="$PROJECT_ITEM_ID" -f fieldId="$field_id" -f optionId="$option_id" >/dev/null
+          }
+
+          set_number_field() {
+            local field_name="$1"
+            local number_value="$2"
+
+            local field_id
+            field_id=$(get_field_id "$field_name")
+            if [[ -z "$field_id" ]]; then
+              echo "ERROR: project field '$field_name' not found."
+              exit 1
+            fi
+
+            gh api graphql -f query='mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $numberValue:Float!) { updateProjectV2ItemFieldValue(input: { projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{ number:$numberValue } }) { projectV2Item { id } } }' -f projectId="$PROJECT_ID" -f itemId="$PROJECT_ITEM_ID" -f fieldId="$field_id" -F numberValue="$number_value" >/dev/null
+          }
+
+          set_single_select_field "Status" "🚀 In Progress"
+          set_single_select_field "🤩 Refined?" "👎 Unrefined"
+          set_number_field "📏 Estimation" "3"
+          set_single_select_field "👏 Team" "$TEAM_VALUE"
+          set_single_select_field "🚀 Objective" "💪🏻 Strong Foundation - Visibility & Remediation"
+          set_single_select_field "🧩 Quarter" "Quarter 1"
+          set_single_select_field "🤨 Planned?" "❌ Unplanned"
 
           echo "GitHub issue: #$ISSUE_NUMBER"
           TRACKING_COMMENT="Tracked in #$ISSUE_NUMBER ($ISSUE_URL)"

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -278,7 +278,7 @@ jobs:
             )
 
             if [[ "$COMMENT_EXISTS" == "true" ]]; then
-              echo "Tracking comment already exists on PR #$NUM"
+              echo "Tracking comments already exists on PR #$NUM"
               continue
             fi
 

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -282,7 +282,7 @@ jobs:
             )
 
             if [[ "$COMMENT_EXISTS" == "true" ]]; then
-              echo "Tracking comments already exists on PR #$NUM"
+              echo "Tracking comment already exists on PR #$NUM"
               continue
             fi
 

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -282,7 +282,7 @@ jobs:
             )
 
             if [[ "$COMMENT_EXISTS" == "true" ]]; then
-              echo "Tracking comment already exists on PR #$NUM"
+              echo "Tracking comments already exists on PR #$NUM"
               continue
             fi
 

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -117,6 +117,7 @@ jobs:
             | jq -c --arg title "$ISSUE_TITLE" 'map(select(.title == $title)) | .[0] // empty')
 
           if [[ -z "$EXISTING_ISSUE" ]]; then
+            CREATED_ISSUE=true
             echo "Creating GitHub issue for $REPO_NAME"
             PAYLOAD=$(jq -n --arg title "$ISSUE_TITLE" --arg body "$ISSUE_BODY" \
               '{ title: $title, body: $body }')
@@ -131,6 +132,7 @@ jobs:
             ISSUE_URL=$(echo "$CREATE" | jq -r '.html_url // empty')
             ISSUE_NODE_ID=$(echo "$CREATE" | jq -r '.node_id // empty')
           else
+            CREATED_ISSUE=false
             ISSUE_NUMBER=$(echo "$EXISTING_ISSUE" | jq -r '.number')
             ISSUE_URL=$(echo "$EXISTING_ISSUE" | jq -r '.url')
             ISSUE_NODE_ID=$(echo "$EXISTING_ISSUE" | jq -r '.id // empty')
@@ -260,13 +262,15 @@ jobs:
             gh api graphql -f query="mutation(\$projectId:ID!, \$itemId:ID!, \$fieldId:ID!, \$numberValue:Float!) { updateProjectV2ItemFieldValue(input: { projectId:\$projectId, itemId:\$itemId, fieldId:\$fieldId, value:{ number:\$numberValue } }) { projectV2Item { id } } }" -f projectId="$PROJECT_ID" -f itemId="$PROJECT_ITEM_ID" -f fieldId="$field_id" -F numberValue="$number_value" >/dev/null
           }
 
-          set_single_select_field "Status" "👇 To do"
-          set_single_select_field "🤩 Refined?" "👎 Unrefined"
-          set_number_field "Estimation" "3"
-          set_single_select_field "👏 Team" "$TEAM_VALUE"
-          set_single_select_field "🚀 Objective" "💪🏻 Strong Foundation - Visibility & Remediation"
-          set_single_select_field "🧩 Quarter" "Quarter 1"
-          set_single_select_field "🤨 Planned?" "❌ Unplanned"
+          if [[ "$CREATED_ISSUE" == "true" ]]; then
+            set_single_select_field "Status" "👇 To do"
+            set_single_select_field "🤩 Refined?" "👎 Unrefined"
+            set_number_field "Estimation" "2"
+            set_single_select_field "👏 Team" "$TEAM_VALUE"
+            set_single_select_field "🚀 Objective" "💪🏻 Strong Foundation - Visibility & Remediation"
+            set_single_select_field "🧩 Quarter" "Quarter 1"
+            set_single_select_field "🤨 Planned?" "❌ Unplanned"
+          fi
 
           echo "GitHub issue: #$ISSUE_NUMBER"
           TRACKING_COMMENT="Tracked in #$ISSUE_NUMBER ($ISSUE_URL)"

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -262,7 +262,7 @@ jobs:
 
           set_single_select_field "Status" "👇 To do"
           set_single_select_field "🤩 Refined?" "👎 Unrefined"
-          set_number_field "📏 Estimation" "3"
+          set_number_field "Estimation" "3"
           set_single_select_field "👏 Team" "$TEAM_VALUE"
           set_single_select_field "🚀 Objective" "💪🏻 Strong Foundation - Visibility & Remediation"
           set_single_select_field "🧩 Quarter" "Quarter 1"

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -232,15 +232,15 @@ jobs:
             local field_id
             field_id=$(get_field_id "$field_name")
             if [[ -z "$field_id" ]]; then
-              echo "ERROR: project field '$field_name' not found."
-              exit 1
+              echo "WARNING: project field '$field_name' not found; skipping."
+              return 0
             fi
 
             local option_id
             option_id=$(get_single_select_option_id "$field_name" "$option_value")
             if [[ -z "$option_id" ]]; then
-              echo "ERROR: option '$option_value' not found for field '$field_name'."
-              exit 1
+              echo "WARNING: option '$option_value' not found for field '$field_name'; skipping."
+              return 0
             fi
 
             gh api graphql -f query="mutation(\$projectId:ID!, \$itemId:ID!, \$fieldId:ID!, \$optionId:String!) { updateProjectV2ItemFieldValue(input: { projectId:\$projectId, itemId:\$itemId, fieldId:\$fieldId, value:{ singleSelectOptionId:\$optionId } }) { projectV2Item { id } } }" -f projectId="$PROJECT_ID" -f itemId="$PROJECT_ITEM_ID" -f fieldId="$field_id" -f optionId="$option_id" >/dev/null
@@ -253,8 +253,8 @@ jobs:
             local field_id
             field_id=$(get_field_id "$field_name")
             if [[ -z "$field_id" ]]; then
-              echo "ERROR: project field '$field_name' not found."
-              exit 1
+              echo "WARNING: project field '$field_name' not found; skipping."
+              return 0
             fi
 
             gh api graphql -f query="mutation(\$projectId:ID!, \$itemId:ID!, \$fieldId:ID!, \$numberValue:Float!) { updateProjectV2ItemFieldValue(input: { projectId:\$projectId, itemId:\$itemId, fieldId:\$fieldId, value:{ number:\$numberValue } }) { projectV2Item { id } } }" -f projectId="$PROJECT_ID" -f itemId="$PROJECT_ITEM_ID" -f fieldId="$field_id" -F numberValue="$number_value" >/dev/null

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3 #todo sha pin
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -260,7 +260,7 @@ jobs:
             gh api graphql -f query="mutation(\$projectId:ID!, \$itemId:ID!, \$fieldId:ID!, \$numberValue:Float!) { updateProjectV2ItemFieldValue(input: { projectId:\$projectId, itemId:\$itemId, fieldId:\$fieldId, value:{ number:\$numberValue } }) { projectV2Item { id } } }" -f projectId="$PROJECT_ID" -f itemId="$PROJECT_ITEM_ID" -f fieldId="$field_id" -F numberValue="$number_value" >/dev/null
           }
 
-          set_single_select_field "Status" "🚀 In Progress"
+          set_single_select_field "Status" "👇 To do"
           set_single_select_field "🤩 Refined?" "👎 Unrefined"
           set_number_field "📏 Estimation" "3"
           set_single_select_field "👏 Team" "$TEAM_VALUE"

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -100,14 +100,15 @@ jobs:
 
           echo "$PR_LIST" | jq -r '.[] | "  - #\(.number): \(.title) (branch \(.headRefName), author \(.author.login))"'
 
+          # shellcheck disable=SC2016
           PR_DESCRIPTION=$(echo "$PR_LIST" \
             | jq -r \
               --arg repo "$REPO" \
               '.[] | "PR Number: \(.number)\nTitle: \(.title)\nBranch: \(.headRefName)\nURL: https://github.com/\($repo)/pull/\(.number)\n"')
 
-          ISSUE_BODY=$(jq -n --arg repo "$REPO_NAME" --arg desc "$PR_DESCRIPTION" \
-            -r '"Repository: \($repo)\n\n\($desc)"')
+          ISSUE_BODY=$(printf 'Repository: %s\n\n%s' "$REPO_NAME" "$PR_DESCRIPTION")
 
+          # shellcheck disable=SC2016
           EXISTING_ISSUE=$(gh issue list \
             --repo "$REPO" \
             --state open \
@@ -136,8 +137,9 @@ jobs:
 
             echo "Updating GitHub issue #$ISSUE_NUMBER"
             NOW=$(date '+%Y-%m-%d %H:%M:%S')
-            UPDATE_PAYLOAD=$(jq -n --arg title "$ISSUE_TITLE" --arg repo "$REPO_NAME" --arg now "$NOW" --arg desc "$PR_DESCRIPTION" \
-              '{ title: $title, body: "Updated on \($now)\nRepository: \($repo)\n\n\($desc)" }')
+            UPDATE_BODY=$(printf 'Updated on %s\nRepository: %s\n\n%s' "$NOW" "$REPO_NAME" "$PR_DESCRIPTION")
+            UPDATE_PAYLOAD=$(jq -n --arg title "$ISSUE_TITLE" --arg body "$UPDATE_BODY" \
+              '{ title: $title, body: $body }')
 
             printf '%s' "$UPDATE_PAYLOAD" | gh api \
               --method PATCH \
@@ -151,7 +153,49 @@ jobs:
             exit 1
           fi
 
-          PROJECT_DATA=$(gh api graphql -f query='query($owner:String!, $title:String!) { organization(login:$owner) { projectsV2(first: 20, query: $title) { nodes { id title fields(first: 50) { nodes { __typename ... on ProjectV2Field { id name } ... on ProjectV2SingleSelectField { id name options { id name } } ... on ProjectV2IterationField { id name configuration { iterations { id title startDate } } } } } } } } }' -f owner="$PROJECT_OWNER" -f title="$PROJECT_TITLE")
+          PROJECT_QUERY=$(cat <<GRAPHQL
+          query(\$owner:String!, \$title:String!) {
+            organization(login:\$owner) {
+              projectsV2(first: 20, query: \$title) {
+                nodes {
+                  id
+                  title
+                  fields(first: 50) {
+                    nodes {
+                      __typename
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                      ... on ProjectV2IterationField {
+                        id
+                        name
+                        configuration {
+                          iterations {
+                            id
+                            title
+                            startDate
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          GRAPHQL
+          )
+
+          PROJECT_DATA=$(gh api graphql -f query="$PROJECT_QUERY" -f owner="$PROJECT_OWNER" -f title="$PROJECT_TITLE")
 
           PROJECT_ID=$(echo "$PROJECT_DATA" | jq -r --arg title "$PROJECT_TITLE" '.data.organization.projectsV2.nodes[] | select(.title == $title) | .id' | head -n1)
           if [[ -z "$PROJECT_ID" ]]; then
@@ -159,10 +203,10 @@ jobs:
             exit 1
           fi
 
-          PROJECT_ITEM_ID=$(gh api graphql -f query='query($issueId:ID!, $projectId:ID!) { node(id:$issueId) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }' -f issueId="$ISSUE_NODE_ID" -f projectId="$PROJECT_ID" | jq -r --arg project "$PROJECT_ID" '.data.node.projectItems.nodes[]? | select(.project.id == $project) | .id' | head -n1)
+          PROJECT_ITEM_ID=$(gh api graphql -f query="query(\$issueId:ID!) { node(id:\$issueId) { ... on Issue { projectItems(first: 100) { nodes { id project { id } } } } } }" -f issueId="$ISSUE_NODE_ID" | jq -r --arg project "$PROJECT_ID" ".data.node.projectItems.nodes[]? | select(.project.id == \$project) | .id" | head -n1)
 
           if [[ -z "$PROJECT_ITEM_ID" ]]; then
-            PROJECT_ITEM_ID=$(gh api graphql -f query='mutation($projectId:ID!, $contentId:ID!) { addProjectV2ItemById(input:{ projectId:$projectId, contentId:$contentId }) { item { id } } }' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_NODE_ID" | jq -r '.data.addProjectV2ItemById.item.id // empty')
+            PROJECT_ITEM_ID=$(gh api graphql -f query="mutation(\$projectId:ID!, \$contentId:ID!) { addProjectV2ItemById(input:{ projectId:\$projectId, contentId:\$contentId }) { item { id } } }" -f projectId="$PROJECT_ID" -f contentId="$ISSUE_NODE_ID" | jq -r '.data.addProjectV2ItemById.item.id // empty')
           fi
 
           if [[ -z "$PROJECT_ITEM_ID" ]]; then
@@ -172,13 +216,13 @@ jobs:
 
           get_field_id() {
             local field_name="$1"
-            echo "$PROJECT_DATA" | jq -r --arg name "$field_name" '.data.organization.projectsV2.nodes[].fields.nodes[]? | select(.name == $name) | .id // empty' | head -n1
+            echo "$PROJECT_DATA" | jq -r --arg name "$field_name" ".data.organization.projectsV2.nodes[].fields.nodes[]? | select(.name == \$name) | .id // empty" | head -n1
           }
 
           get_single_select_option_id() {
             local field_name="$1"
             local option_name="$2"
-            echo "$PROJECT_DATA" | jq -r --arg field "$field_name" --arg option "$option_name" '.data.organization.projectsV2.nodes[].fields.nodes[]? | select(.name == $field) | .options[]? | select(.name == $option) | .id // empty' | head -n1
+            echo "$PROJECT_DATA" | jq -r --arg field "$field_name" --arg option "$option_name" ".data.organization.projectsV2.nodes[].fields.nodes[]? | select(.name == \$field) | .options[]? | select(.name == \$option) | .id // empty" | head -n1
           }
 
           set_single_select_field() {
@@ -199,7 +243,7 @@ jobs:
               exit 1
             fi
 
-            gh api graphql -f query='mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!) { updateProjectV2ItemFieldValue(input: { projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{ singleSelectOptionId:$optionId } }) { projectV2Item { id } } }' -f projectId="$PROJECT_ID" -f itemId="$PROJECT_ITEM_ID" -f fieldId="$field_id" -f optionId="$option_id" >/dev/null
+            gh api graphql -f query="mutation(\$projectId:ID!, \$itemId:ID!, \$fieldId:ID!, \$optionId:String!) { updateProjectV2ItemFieldValue(input: { projectId:\$projectId, itemId:\$itemId, fieldId:\$fieldId, value:{ singleSelectOptionId:\$optionId } }) { projectV2Item { id } } }" -f projectId="$PROJECT_ID" -f itemId="$PROJECT_ITEM_ID" -f fieldId="$field_id" -f optionId="$option_id" >/dev/null
           }
 
           set_number_field() {
@@ -213,7 +257,7 @@ jobs:
               exit 1
             fi
 
-            gh api graphql -f query='mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $numberValue:Float!) { updateProjectV2ItemFieldValue(input: { projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:{ number:$numberValue } }) { projectV2Item { id } } }' -f projectId="$PROJECT_ID" -f itemId="$PROJECT_ITEM_ID" -f fieldId="$field_id" -F numberValue="$number_value" >/dev/null
+            gh api graphql -f query="mutation(\$projectId:ID!, \$itemId:ID!, \$fieldId:ID!, \$numberValue:Float!) { updateProjectV2ItemFieldValue(input: { projectId:\$projectId, itemId:\$itemId, fieldId:\$fieldId, value:{ number:\$numberValue } }) { projectV2Item { id } } }" -f projectId="$PROJECT_ID" -f itemId="$PROJECT_ITEM_ID" -f fieldId="$field_id" -F numberValue="$number_value" >/dev/null
           }
 
           set_single_select_field "Status" "🚀 In Progress"

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Create GitHub App token for team discovery
         id: app-token
-        uses: actions/create-github-app-token@v3 #todo sha pin
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         with:
           app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -3,6 +3,7 @@ name: Run Dependabot PR Tracker
 on:
   schedule:
     - cron: "25 9 * * 5"
+      timezone: "Europe/London"
   workflow_dispatch:
   pull_request:
     branches: [main]
@@ -55,12 +56,12 @@ jobs:
     steps:
       - name: Create GitHub App token for team discovery
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@v3 #todo sha pin
         with:
           app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ env.TEAM_ORG }}
-          repositories: ${{ github.event.repository.name }}
+          permission-members: read
 
       - name: Build repository matrix
         id: build-matrix

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -61,6 +61,7 @@ jobs:
           app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ env.TEAM_ORG }}
+          repositories: ${{ github.event.repository.name }}
           permission-members: read
 
       - name: Build repository matrix


### PR DESCRIPTION
This PR is to add and harden the Dependabot PR tracking workflows.

- Extended the reusable tracker workflow to add newly created tracking issues to the Developer Experience GitHub project and set initial metadata such as Team, Status, Objective, Quarter, Refined, Planned, and Estimation.
- Added repository-to-team mapping so project team assignment is derived automatically from the target repository.
- Fixed the project GraphQL logic and workflow lint issues so the reusable workflow runs cleanly.
- Made project metadata updates resilient when optional project fields or options are missing.
- Changed the workflow so project field defaults are only applied when a tracking issue is first created, preventing later runs from overwriting manual changes like Status.
- Kept the dispatcher workflow aligned so it continues discovering team repositories and fan-out running the tracker across them.