### PR TITLE
Monitor GitHub Licenses Workflow

### DIFF
--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -2,6 +2,9 @@ name: Monitor GitHub License Availability
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - feat/204-monitor-gh-licenses
   schedule:
     - cron: "0 9 * * 1-5"
 

--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -18,17 +18,10 @@ jobs:
             contents: read
         steps:
 
-            - name: Generate GitHub App Token
-              id: generate-token
-              uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
-              with:
-                app-id: ${{ secrets.APP_ID }}
-                private-key: ${{ secrets.APP_PRIVATE_KEY }}
-                owner: "ministryofjustice"
-
             - name: Monitor GitHub License Availability
               env:
-                GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+                GITHUB_TOKEN: ${{ secrets.MONITOR_GH_LICENSES_PAT }}
+
               run: |
                 total_seats_purchased=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_purchased')
                 total_seats_consumed=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_consumed')
@@ -64,42 +57,42 @@ jobs:
                 SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} #developer-experience-alerts
               if: ${{ env.remaining_licenses <= 10 }}
 
-            - name: Slack failure notification
-              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-              with:
-                webhook-type: incoming-webhook
-                payload: |
-                  {
-                    "blocks": [
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": ":no_entry: Failed GitHub Action:"
-                        }
-                      },
-                      {
-                        "type": "section",
-                        "fields": [
-                          {
-                            "type": "mrkdwn",
-                            "text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
-                          },
-                          {
-                            "type": "mrkdwn",
-                            "text": "*Job:*\n${{ github.job }}"
-                          },
-                          {
-                            "type": "mrkdwn",
-                            "text": "*Repo:*\n${{ github.repository }}"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-              env:
-                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-              if: ${{ failure() }}
+            # - name: Slack failure notification
+            #   uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+            #   with:
+            #     webhook-type: incoming-webhook
+            #     payload: |
+            #       {
+            #         "blocks": [
+            #           {
+            #             "type": "section",
+            #             "text": {
+            #               "type": "mrkdwn",
+            #               "text": ":no_entry: Failed GitHub Action:"
+            #             }
+            #           },
+            #           {
+            #             "type": "section",
+            #             "fields": [
+            #               {
+            #                 "type": "mrkdwn",
+            #                 "text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+            #               },
+            #               {
+            #                 "type": "mrkdwn",
+            #                 "text": "*Job:*\n${{ github.job }}"
+            #               },
+            #               {
+            #                 "type": "mrkdwn",
+            #                 "text": "*Repo:*\n${{ github.repository }}"
+            #               }
+            #             ]
+            #           }
+            #         ]
+            #       }
+            #   env:
+            #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            #   if: ${{ failure() }}
 
 
 

--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -19,6 +19,7 @@ jobs:
         steps:
 
             - name: Monitor GitHub License Availability
+              id: monitor-licenses
               env:
                 GITHUB_TOKEN: ${{ secrets.MONITOR_GH_LICENSES_PAT }}
 
@@ -26,9 +27,9 @@ jobs:
                 total_seats_purchased=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_purchased')
                 total_seats_consumed=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_consumed')
                 remaining_licenses=$((total_seats_purchased - total_seats_consumed))
-                echo "total_seats_purchased=$total_seats_purchased" #>> $GITHUB_ENV
-                echo "total_seats_consumed=$total_seats_consumed" #>> $GITHUB_ENV
-                echo "remaining_licenses=$remaining_licenses" #>> $GITHUB_ENV
+                echo "total_seats_purchased=$total_seats_purchased" >> $GITHUB_OUTPUT
+                echo "total_seats_consumed=$total_seats_consumed" >> $GITHUB_OUTPUT
+                echo "remaining_licenses=$remaining_licenses" >> $GITHUB_OUTPUT
 
             - name: Notify Slack if licenses are low 
               uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
@@ -48,14 +49,14 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": "There are only ${{ env.remaining_licenses }} available licenses of a total of ${{ env.total_seats_purchased }}. Refer to the <https://ministryofjustice.github.io/developer-experience-documentation/runbooks/how-to-remove-a-dormant-github-user.html|runbook: How to remove a dormant GitHub user> to free up available licenses."
+                          "text": "There are only ${{ steps.monitor-licenses.outputs.remaining_licenses }} available licenses of a total of ${{ steps.monitor-licenses.outputs.total_seats_purchased }}. Refer to the runbook:<https://ministryofjustice.github.io/developer-experience-documentation/runbooks/how-to-remove-a-dormant-github-user.html|How to remove a dormant GitHub user> to free up available licenses."
                         }
                       }
                     ]
                   }
               env:
                 SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} #developer-experience-alerts
-              if: ${{ env.remaining_licenses <= 10 }}
+              if: ${{ steps.monitor-licenses.outputs.remaining_licenses <= 50 }}
 
             # - name: Slack failure notification
             #   uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -7,89 +7,90 @@ on:
     - cron: "0 9 * * 1-5"
 
 permissions: {}
-
 env:
   LICENSE_THRESHOLD: 10
 
 jobs:
-    monitor-github-licenses:
-        name: Monitor GitHub License Availability
-        runs-on: ubuntu-latest
-        steps:
-            - name: Monitor GitHub License Availability
-              id: monitor-licenses
-              env:
-                GITHUB_TOKEN: ${{ secrets.MONITOR_GH_LICENSES_PAT }}  # tied to personal account with access to the GitHub Enterprise
+  monitor-github-licenses:
+    name: Monitor GitHub License Availability
+    runs-on: ubuntu-latest
+    steps:
+      - name: Monitor GitHub License Availability
+        id: monitor-licenses
+        env:
+          GITHUB_TOKEN: ${{ secrets.MONITOR_GH_LICENSES_PAT }}  # tied to personal account with access to the GitHub Enterprise
 
-              run: |
-                total_seats_purchased=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_purchased')
-                total_seats_consumed=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_consumed')
-                remaining_licenses=$((total_seats_purchased - total_seats_consumed))
+        run: |
+          total_seats_purchased=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_purchased')
+          total_seats_consumed=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_consumed')
+          remaining_licenses=$((total_seats_purchased - total_seats_consumed))
 
-                echo "total_seats_purchased=$total_seats_purchased" >> $GITHUB_OUTPUT
-                echo "total_seats_consumed=$total_seats_consumed" >> $GITHUB_OUTPUT
-                echo "remaining_licenses=$remaining_licenses" >> $GITHUB_OUTPUT
+          {
+            echo "total_seats_purchased=$total_seats_purchased"
+            echo "total_seats_consumed=$total_seats_consumed"
+            echo "remaining_licenses=$remaining_licenses"
+          } >> "$GITHUB_OUTPUT"
 
-            - name: Notify Slack if licenses are low 
-              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-              with:
-                webhook-type: incoming-webhook
-                payload: |
-                  {
-                    "blocks": [
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": ":warning: GitHub License Availability is low!"
-                        }
-                      },
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": "There are only ${{ steps.monitor-licenses.outputs.remaining_licenses }} available licenses of a total of ${{ steps.monitor-licenses.outputs.total_seats_purchased }}. Refer to the runbook: <https://ministryofjustice.github.io/developer-experience-documentation/runbooks/how-to-remove-a-dormant-github-user.html|How to remove a dormant GitHub user> to free up available licenses."
-                        }
-                      }
-                    ]
+      - name: Notify Slack if licenses are low
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: GitHub License Availability is low!"
                   }
-              env:
-                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} #developer-experience-alerts
-              if: ${{ steps.monitor-licenses.outputs.remaining_licenses <= env.LICENSE_THRESHOLD }}
-
-            - name: Slack failure notification
-              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-              with:
-                webhook-type: incoming-webhook
-                payload: |
-                  {
-                    "blocks": [
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": ":no_entry: Failed GitHub Action:"
-                        }
-                      },
-                      {
-                        "type": "section",
-                        "fields": [
-                          {
-                            "type": "mrkdwn",
-                            "text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
-                          },
-                          {
-                            "type": "mrkdwn",
-                            "text": "*Job:*\n${{ github.job }}"
-                          },
-                          {
-                            "type": "mrkdwn",
-                            "text": "*Repo:*\n${{ github.repository }}"
-                          }
-                        ]
-                      }
-                    ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "There are only ${{ steps.monitor-licenses.outputs.remaining_licenses }} available licenses of a total of ${{ steps.monitor-licenses.outputs.total_seats_purchased }}. Refer to the runbook: <https://ministryofjustice.github.io/developer-experience-documentation/runbooks/how-to-remove-a-dormant-github-user.html|How to remove a dormant GitHub user> to free up available licenses."
                   }
-              env:
-                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-              if: ${{ failure() }}
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}  #developer-experience-alerts
+        if: ${{ steps.monitor-licenses.outputs.remaining_licenses <= env.LICENSE_THRESHOLD }}
+
+      - name: Slack failure notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":no_entry: Failed GitHub Action:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Job:*\n${{ github.job }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repo:*\n${{ github.repository }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -8,7 +8,7 @@ on:
 
 permissions: {}
 env:
-  LICENSE_THRESHOLD: 50
+  LICENSE_THRESHOLD: 10
 
 jobs:
   monitor-github-licenses:

--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -8,7 +8,7 @@ on:
 
 permissions: {}
 env:
-  LICENSE_THRESHOLD: 10
+  LICENSE_THRESHOLD: 50
 
 jobs:
   monitor-github-licenses:

--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -9,6 +9,8 @@ on:
     - cron: "0 9 * * 1-5"
 
 permissions: {}
+env:
+  LICENSE_THRESHOLD: 10
 
 jobs:
     monitor-github-licenses:
@@ -27,6 +29,7 @@ jobs:
                 total_seats_purchased=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_purchased')
                 total_seats_consumed=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_consumed')
                 remaining_licenses=$((total_seats_purchased - total_seats_consumed))
+
                 echo "total_seats_purchased=$total_seats_purchased" >> $GITHUB_OUTPUT
                 echo "total_seats_consumed=$total_seats_consumed" >> $GITHUB_OUTPUT
                 echo "remaining_licenses=$remaining_licenses" >> $GITHUB_OUTPUT
@@ -49,51 +52,51 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": "There are only ${{ steps.monitor-licenses.outputs.remaining_licenses }} available licenses of a total of ${{ steps.monitor-licenses.outputs.total_seats_purchased }}. Refer to the runbook:<https://ministryofjustice.github.io/developer-experience-documentation/runbooks/how-to-remove-a-dormant-github-user.html|How to remove a dormant GitHub user> to free up available licenses."
+                          "text": "There are only ${{ steps.monitor-licenses.outputs.remaining_licenses }} available licenses of a total of ${{ steps.monitor-licenses.outputs.total_seats_purchased }}. Refer to the runbook: <https://ministryofjustice.github.io/developer-experience-documentation/runbooks/how-to-remove-a-dormant-github-user.html|How to remove a dormant GitHub user> to free up available licenses."
                         }
                       }
                     ]
                   }
               env:
                 SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} #developer-experience-alerts
-              if: ${{ steps.monitor-licenses.outputs.remaining_licenses <= 50 }}
+              if: ${{ steps.monitor-licenses.outputs.remaining_licenses <= env.LICENSE_THRESHOLD }}
 
-            # - name: Slack failure notification
-            #   uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-            #   with:
-            #     webhook-type: incoming-webhook
-            #     payload: |
-            #       {
-            #         "blocks": [
-            #           {
-            #             "type": "section",
-            #             "text": {
-            #               "type": "mrkdwn",
-            #               "text": ":no_entry: Failed GitHub Action:"
-            #             }
-            #           },
-            #           {
-            #             "type": "section",
-            #             "fields": [
-            #               {
-            #                 "type": "mrkdwn",
-            #                 "text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
-            #               },
-            #               {
-            #                 "type": "mrkdwn",
-            #                 "text": "*Job:*\n${{ github.job }}"
-            #               },
-            #               {
-            #                 "type": "mrkdwn",
-            #                 "text": "*Repo:*\n${{ github.repository }}"
-            #               }
-            #             ]
-            #           }
-            #         ]
-            #       }
-            #   env:
-            #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-            #   if: ${{ failure() }}
+            - name: Slack failure notification
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+              with:
+                webhook-type: incoming-webhook
+                payload: |
+                  {
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": ":no_entry: Failed GitHub Action:"
+                        }
+                      },
+                      {
+                        "type": "section",
+                        "fields": [
+                          {
+                            "type": "mrkdwn",
+                            "text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+                          },
+                          {
+                            "type": "mrkdwn",
+                            "text": "*Job:*\n${{ github.job }}"
+                          },
+                          {
+                            "type": "mrkdwn",
+                            "text": "*Repo:*\n${{ github.repository }}"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+              env:
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+              if: ${{ failure() }}
 
 
 

--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -10,7 +10,7 @@ on:
 
 permissions: {}
 env:
-  LICENSE_THRESHOLD: 10
+  LICENSE_THRESHOLD: 50
 
 jobs:
     monitor-github-licenses:

--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -1,0 +1,106 @@
+name: Monitor GitHub License Availability
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * 1-5"
+
+permissions: {}
+
+jobs:
+    monitor-github-licenses:
+        name: Monitor GitHub License Availability
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+
+            - name: Generate GitHub App Token
+              id: generate-token
+              uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+              with:
+                app-id: ${{ secrets.APP_ID }}
+                private-key: ${{ secrets.APP_PRIVATE_KEY }}
+                owner: "ministryofjustice"
+
+            - name: Monitor GitHub License Availability
+              env:
+                GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+              run: |
+                total_seats_purchased=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_purchased')
+                total_seats_consumed=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_consumed')
+                remaining_licenses=$((total_seats_purchased - total_seats_consumed))
+                echo "total_seats_purchased=$total_seats_purchased" >> $GITHUB_ENV
+                echo "total_seats_consumed=$total_seats_consumed" >> $GITHUB_ENV
+                echo "remaining_licenses=$remaining_licenses" >> $GITHUB_ENV
+
+            - name: Notify Slack if licenses are low 
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+              with:
+                webhook-type: incoming-webhook
+                payload: |
+                  {
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": ":warning: GitHub License Availability is low!"
+                        }
+                      },
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": "There are only ${{ env.remaining_licenses }} available licenses of a total of ${{ env.total_seats_purchased }}. Refer to the <https://ministryofjustice.github.io/developer-experience-documentation/runbooks/how-to-remove-a-dormant-github-user.html|runbook: How to remove a dormant GitHub user> to free up available licenses."
+                        }
+                      }
+                    ]
+                  }
+              env:
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} #developer-experience-alerts
+              if: ${{ env.remaining_licenses <= 10 }}
+
+            - name: Slack failure notification
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+              with:
+                webhook-type: incoming-webhook
+                payload: |
+                  {
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": ":no_entry: Failed GitHub Action:"
+                        }
+                      },
+                      {
+                        "type": "section",
+                        "fields": [
+                          {
+                            "type": "mrkdwn",
+                            "text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+                          },
+                          {
+                            "type": "mrkdwn",
+                            "text": "*Job:*\n${{ github.job }}"
+                          },
+                          {
+                            "type": "mrkdwn",
+                            "text": "*Repo:*\n${{ github.repository }}"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+              env:
+                SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+              if: ${{ failure() }}
+
+
+
+
+                
+                
+

--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -2,28 +2,24 @@ name: Monitor GitHub License Availability
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - feat/204-monitor-gh-licenses
+
   schedule:
     - cron: "0 9 * * 1-5"
 
 permissions: {}
+
 env:
-  LICENSE_THRESHOLD: 50
+  LICENSE_THRESHOLD: 10
 
 jobs:
     monitor-github-licenses:
         name: Monitor GitHub License Availability
         runs-on: ubuntu-latest
-        permissions:
-            contents: read
         steps:
-
             - name: Monitor GitHub License Availability
               id: monitor-licenses
               env:
-                GITHUB_TOKEN: ${{ secrets.MONITOR_GH_LICENSES_PAT }}
+                GITHUB_TOKEN: ${{ secrets.MONITOR_GH_LICENSES_PAT }}  # tied to personal account with access to the GitHub Enterprise
 
               run: |
                 total_seats_purchased=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_purchased')
@@ -97,10 +93,3 @@ jobs:
               env:
                 SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
               if: ${{ failure() }}
-
-
-
-
-                
-                
-

--- a/.github/workflows/monitor-gh-licenses.yml
+++ b/.github/workflows/monitor-gh-licenses.yml
@@ -26,9 +26,9 @@ jobs:
                 total_seats_purchased=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_purchased')
                 total_seats_consumed=$(gh api /enterprises/ministry-of-justice-uk/consumed-licenses -q '.total_seats_consumed')
                 remaining_licenses=$((total_seats_purchased - total_seats_consumed))
-                echo "total_seats_purchased=$total_seats_purchased" >> $GITHUB_ENV
-                echo "total_seats_consumed=$total_seats_consumed" >> $GITHUB_ENV
-                echo "remaining_licenses=$remaining_licenses" >> $GITHUB_ENV
+                echo "total_seats_purchased=$total_seats_purchased" #>> $GITHUB_ENV
+                echo "total_seats_consumed=$total_seats_consumed" #>> $GITHUB_ENV
+                echo "remaining_licenses=$remaining_licenses" #>> $GITHUB_ENV
 
             - name: Notify Slack if licenses are low 
               uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository provides centralized, reusable GitHub Actions workflows and auto
 ## Purpose
 
 This repository centralizes ownership of reusable GitHub workflows to:
+
 - Improve consistency across MoJ repositories
 - Reduce duplication and drift between teams
 - Enable standardization of CI/CD and automation patterns
@@ -17,10 +18,16 @@ This repository centralizes ownership of reusable GitHub workflows to:
 This repository provides several categories of workflows:
 
 ### Member Management
+
 - **Add Members to Root Team (MoJ)** - Automated workflow that ensures GitHub organization members are added to root team for `ministryofjustice` organization
 - **Add Members to Root Team (MoJAS)** - Automated workflow that ensures GitHub organization members are added to root team for `moj-analytical-services` organization
 
+### Monitoring & Alerts
+
+- **Monitor GitHub License Availability** - Monitors GitHub Enterprise license consumption and sends Slack alerts when remaining licenses are low
+
 ### CI/CD
+
 - **Dependency Review** - Security scanning for dependency vulnerabilities in pull requests
 - **Lint** - Validates GitHub Actions workflows, Markdown, and YAML files on pull requests
 - **CodeQL** - Performs static application security testing on pull requests, main branch pushes, and a weekly schedule
@@ -94,5 +101,6 @@ This repository follows the [Ministry of Justice GitHub Repository Standards](ht
 ## Support
 
 For questions or issues:
+
 - Open an issue in this repository
 - Contact the DevX Engineering Platform team


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/ministry-of-justice-engineering-platform/issues/32 

## Changes
This pull request introduces a new GitHub Actions workflow to monitor GitHub license availability and notify the team via Slack if available licenses fall below a certain threshold. The workflow runs both on a schedule and manually, and includes Slack notifications for both low license counts and workflow failures.

**GitHub License Monitoring Workflow:**

* Added a new workflow file, `.github/workflows/monitor-gh-licenses.yml`, to automate monitoring of GitHub license usage and availability.

  **Monitoring and Notification:**
  * The workflow checks the number of purchased and consumed GitHub Enterprise licenses, calculates the remaining licenses, and outputs these values for use in subsequent steps.
  * If the number of remaining licenses falls below the defined threshold (default: 10), a Slack notification is sent to alert the team, including a link to the runbook for freeing up licenses.

  **Failure Handling:**
  * If the workflow fails for any reason, a separate Slack notification is sent with details about the failure, including workflow and job information.

  **Scheduling and Permissions:**
  * The workflow is configured to run on both manual trigger (`workflow_dispatch`) and a weekday schedule (Monday–Friday at 9:00 UTC).
  * Minimal permissions are used for security

## Limitations

  **Authentication:**
  * A personal classic PAT token is used to authenticate with GitHub which seems to be an unfortunate limitation when querying this particular API. The [documentation](https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin/licensing?apiVersion=2026-03-10#list-enterprise-consumed-licenses) suggest GH App and Fine Grained tokens are compatible however when I tested them there were no options available for the required permissions. We could consider creating a DevEx BOT GitHub account so that the value can be rotated by anyone in the team.

