### PR TITLE
28: Dependabot PRs for ministry-of-justice-engineering-platform

### DIFF
--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/reusable-add-members-to-root-team.yml
+++ b/.github/workflows/reusable-add-members-to-root-team.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Generate GitHub App Token
         id: generate-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets['app-id'] }}
           private-key: ${{ secrets['app-private-key'] }}

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Create GitHub App token for team discovery
         id: app-token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Resolves #28

- actions/create-github-app-token: v1.11.0 -> v3.2.0

Note: warning presented regarding `app-id` being deprecated in favour of `client-id`: beyond scope of ticket, will raise a small issue to fix