### PR TITLE
Dependabot PR Cleanup and App-Id to Client-Id deprecation fix

### DIFF
--- a/.github/workflows/add-members-to-root-team-moj.yml
+++ b/.github/workflows/add-members-to-root-team-moj.yml
@@ -17,7 +17,7 @@ jobs:
       organization-name: "ministryofjustice"
       python-version: "3.11"
     secrets:
-      app-id: ${{ secrets.APP_ID }}
+      app-client-id: ${{ secrets.APP_CLIENT_ID }}
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       logging-level: ${{ secrets.LOGGING_LEVEL }}

--- a/.github/workflows/add-members-to-root-team-moj.yml
+++ b/.github/workflows/add-members-to-root-team-moj.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - .github/workflows/reusable-add-members-to-root-team.yml
+      - .github/workflows/add-members-to-root-team-moj.yml
   workflow_dispatch:
   schedule:
     - cron: "0 8,10,12,14,16 * * 1-5"

--- a/.github/workflows/add-members-to-root-team-moj.yml
+++ b/.github/workflows/add-members-to-root-team-moj.yml
@@ -4,6 +4,8 @@ name: 🤖 Add GitHub Members to Root Team (MoJ)
 on:
   pull_request:
     branches: [main]
+    paths:
+      - .github/workflows/reusable-add-members-to-root-team.yml
   workflow_dispatch:
   schedule:
     - cron: "0 8,10,12,14,16 * * 1-5"

--- a/.github/workflows/add-members-to-root-team-moj.yml
+++ b/.github/workflows/add-members-to-root-team-moj.yml
@@ -2,6 +2,8 @@
 name: 🤖 Add GitHub Members to Root Team (MoJ)
 
 on:
+  pull_request:
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: "0 8,10,12,14,16 * * 1-5"

--- a/.github/workflows/add-members-to-root-team-mojas.yml
+++ b/.github/workflows/add-members-to-root-team-mojas.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - .github/workflows/reusable-add-members-to-root-team.yml
+      - .github/workflows/add-members-to-root-team-mojas.yml
   workflow_dispatch:
   schedule:
     - cron: "0 8,10,12,14,16 * * 1-5"

--- a/.github/workflows/add-members-to-root-team-mojas.yml
+++ b/.github/workflows/add-members-to-root-team-mojas.yml
@@ -3,7 +3,7 @@ name: 🤖 Add GitHub Members to Root Team (MoJAS)
 
 on:
   pull_request:
-      branches: [main]
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: "0 8,10,12,14,16 * * 1-5"

--- a/.github/workflows/add-members-to-root-team-mojas.yml
+++ b/.github/workflows/add-members-to-root-team-mojas.yml
@@ -2,6 +2,8 @@
 name: 🤖 Add GitHub Members to Root Team (MoJAS)
 
 on:
+  pull_request:
+      branches: [main]
   workflow_dispatch:
   schedule:
     - cron: "0 8,10,12,14,16 * * 1-5"

--- a/.github/workflows/add-members-to-root-team-mojas.yml
+++ b/.github/workflows/add-members-to-root-team-mojas.yml
@@ -17,7 +17,7 @@ jobs:
       organization-name: "moj-analytical-services"
       python-version: "3.11"
     secrets:
-      app-id: ${{ secrets.APP_ID }}
+      app-client-id: ${{ secrets.APP_CLIENT_ID }}
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       logging-level: ${{ secrets.LOGGING_LEVEL }}

--- a/.github/workflows/add-members-to-root-team-mojas.yml
+++ b/.github/workflows/add-members-to-root-team-mojas.yml
@@ -4,6 +4,8 @@ name: 🤖 Add GitHub Members to Root Team (MoJAS)
 on:
   pull_request:
     branches: [main]
+    paths:
+      - .github/workflows/reusable-add-members-to-root-team.yml
   workflow_dispatch:
   schedule:
     - cron: "0 8,10,12,14,16 * * 1-5"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -9,10 +9,10 @@ on:
         type: string
     secrets:
       APP_CLIENT_ID:
-        description: "GitHub App Client ID"
+        description: "GitHub App Client ID for Dependabot PR Tracker"
         required: true
       APP_PRIVATE_KEY:
-        description: "GitHub App private key"
+        description: "GitHub App private key for Dependabot PR Tracker"
         required: true
 
 jobs:

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -45,7 +45,7 @@ jobs:
           repositories: ${{ steps.target.outputs.name }}
           permission-issues: write
           permission-organization-projects: write
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -11,6 +11,9 @@ on:
       APP_ID:
         description: "GitHub App ID"
         required: true
+      APP_CLIENT_ID:
+        description: "GitHub App Client ID"
+        required: true
       APP_PRIVATE_KEY:
         description: "GitHub App private key"
         required: true

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -39,7 +39,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.APP_ID }}
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ steps.target.outputs.owner }}
           repositories: ${{ steps.target.outputs.name }}

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -39,7 +39,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ steps.target.outputs.owner }}
           repositories: ${{ steps.target.outputs.name }}

--- a/.github/workflows/dependabot-pr-tracker.yml
+++ b/.github/workflows/dependabot-pr-tracker.yml
@@ -8,9 +8,6 @@ on:
         required: true
         type: string
     secrets:
-      APP_ID:
-        description: "GitHub App ID"
-        required: true
       APP_CLIENT_ID:
         description: "GitHub App Client ID"
         required: true
@@ -42,7 +39,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ steps.target.outputs.owner }}
           repositories: ${{ steps.target.outputs.name }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@6b51ade7a9e4a75a7ad929842dd298a3804ebe8b # v23.1.0
+        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
         with:
           globs: "**/*.md"
 

--- a/.github/workflows/ossf.yml
+++ b/.github/workflows/ossf.yml
@@ -38,6 +38,6 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: ossf.sarif

--- a/.github/workflows/reusable-add-members-to-root-team.yml
+++ b/.github/workflows/reusable-add-members-to-root-team.yml
@@ -59,7 +59,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets['app-id'] }}
+          client-id: ${{ secrets['app-id'] }}
           private-key: ${{ secrets['app-private-key'] }}
           owner: ${{ inputs['organization-name'] }}
 

--- a/.github/workflows/reusable-add-members-to-root-team.yml
+++ b/.github/workflows/reusable-add-members-to-root-team.yml
@@ -59,7 +59,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets['app-id'] }}
+          app-id: ${{ secrets['app-id'] }}
           private-key: ${{ secrets['app-private-key'] }}
           owner: ${{ inputs['organization-name'] }}
 

--- a/.github/workflows/reusable-add-members-to-root-team.yml
+++ b/.github/workflows/reusable-add-members-to-root-team.yml
@@ -14,11 +14,11 @@ on:
         type: string
         default: "3.11"
     secrets:
-      app-id:
-        description: "GitHub App ID"
+      app-client-id:
+        description: "GitHub App Client ID for user sync app"
         required: true
       app-private-key:
-        description: "GitHub App private key"
+        description: "GitHub App private key for user sync app"
         required: true
       slack-webhook-url:
         description: "Slack webhook URL for notifications"
@@ -59,7 +59,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets['app-id'] }}
+          client-id: ${{ secrets['app-client-id'] }}
           private-key: ${{ secrets['app-private-key'] }}
           owner: ${{ inputs['organization-name'] }}
 

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -58,7 +58,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
+          client-id: ${{ secrets.REPO_ISSUE_APP_CLIENT_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ env.TEAM_ORG }}
           repositories: ${{ github.event.repository.name }}
@@ -94,5 +94,5 @@ jobs:
     with:
       repo: ${{ matrix.repo }}
     secrets:
-      APP_ID: ${{ secrets.REPO_ISSUE_APP_ID }}
+      APP_CLIENT_ID: ${{ secrets.REPO_ISSUE_APP_CLIENT_ID }}
       APP_PRIVATE_KEY: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -94,6 +94,5 @@ jobs:
     with:
       repo: ${{ matrix.repo }}
     secrets:
-      APP_ID: ${{ secrets.REPO_ISSUE_APP_ID }}
       APP_CLIENT_ID: ${{ secrets.REPO_ISSUE_APP_CLIENT_ID }}
       APP_PRIVATE_KEY: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -58,7 +58,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.REPO_ISSUE_APP_ID }}
+          client-id: ${{ secrets.REPO_ISSUE_APP_CLIENT_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ env.TEAM_ORG }}
           repositories: ${{ github.event.repository.name }}
@@ -94,5 +94,5 @@ jobs:
     with:
       repo: ${{ matrix.repo }}
     secrets:
-      APP_ID: ${{ secrets.REPO_ISSUE_APP_ID }}
+      APP_ID: ${{ secrets.REPO_ISSUE_APP_CLIENT_ID }}
       APP_PRIVATE_KEY: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -58,7 +58,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
+          client-id: ${{ secrets.REPO_ISSUE_APP_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ env.TEAM_ORG }}
           repositories: ${{ github.event.repository.name }}

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -58,7 +58,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.REPO_ISSUE_APP_CLIENT_ID }}
+          app-id: ${{ secrets.REPO_ISSUE_APP_CLIENT_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ env.TEAM_ORG }}
           repositories: ${{ github.event.repository.name }}

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -94,5 +94,6 @@ jobs:
     with:
       repo: ${{ matrix.repo }}
     secrets:
+      APP_ID: ${{ secrets.REPO_ISSUE_APP_ID }}
       APP_CLIENT_ID: ${{ secrets.REPO_ISSUE_APP_CLIENT_ID }}
       APP_PRIVATE_KEY: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}

--- a/.github/workflows/run-dependabot-pr-tracker.yml
+++ b/.github/workflows/run-dependabot-pr-tracker.yml
@@ -58,7 +58,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.REPO_ISSUE_APP_CLIENT_ID }}
+          app-id: ${{ secrets.REPO_ISSUE_APP_ID }}
           private-key: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}
           owner: ${{ env.TEAM_ORG }}
           repositories: ${{ github.event.repository.name }}
@@ -94,5 +94,5 @@ jobs:
     with:
       repo: ${{ matrix.repo }}
     secrets:
-      APP_ID: ${{ secrets.REPO_ISSUE_APP_CLIENT_ID }}
+      APP_ID: ${{ secrets.REPO_ISSUE_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.REPO_ISSUE_APP_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
       organization-name: "ministryofjustice"
       python-version: "3.11"
     secrets:
-      app-id: ${{ secrets.APP_ID }}
+      client-id: ${{ secrets.APP_CLIENT_ID }}
       app-private-key: ${{ secrets.APP_PRIVATE_KEY }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```

--- a/docs/WORKFLOWS_RUNBOOK.md
+++ b/docs/WORKFLOWS_RUNBOOK.md
@@ -57,7 +57,7 @@ graph LR
 ```
 
 **Token Generation**:
-1. Workflow reads `APP_ID` and `APP_PRIVATE_KEY` from secrets
+1. Workflow reads `APP_CLIENT_ID` and `APP_PRIVATE_KEY` from secrets
 2. Uses `actions/create-github-app-token` to generate a temporary token
 3. Token is valid for 1 hour
 4. Token is scoped to the specific organization
@@ -92,7 +92,7 @@ The Python script (`scripts.add_users_all_org_members_github_team`):
 
 | Secret Name | Type | Description | How to Get |
 |------------|------|-------------|------------|
-| `APP_ID` | Repository Secret | GitHub App ID | From enterprise app settings page |
+| `APP_CLIENT_ID` | Repository Secret | GitHub App Client ID | From enterprise app settings page |
 | `APP_PRIVATE_KEY` | Repository Secret | Private key in PEM format | Generated for the same enterprise app |
 
 The same app credentials are used for both workflows, but the app must be installed in both `ministryofjustice` and `moj-analytical-services` organizations.
@@ -184,10 +184,10 @@ The GitHub App must have these permissions:
 Error: Bad credentials
 ```
 
-**Cause**: APP_ID or APP_PRIVATE_KEY is incorrect
+**Cause**: APP_CLIENT_ID or APP_PRIVATE_KEY is incorrect
 
 **Solution**:
-1. Verify APP_ID matches the app settings page
+1. Verify APP_CLIENT_ID matches the app settings page
 2. Regenerate private key and update secret
 3. Ensure entire PEM file was copied (including BEGIN/END lines)
 
@@ -277,10 +277,10 @@ Error: The job running on runner has exceeded the maximum execution time of X mi
    # In workflow file, add debug step:
    - name: Debug
      run: |
-       echo "APP_ID length: ${#APP_ID}"
+       echo "APP_CLIENT_ID length: ${#APP_CLIENT_ID}"
        echo "Key length: ${#APP_PRIVATE_KEY}"
      env:
-       APP_ID: ${{ secrets.APP_ID }}
+       APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
        APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
    ```
 

--- a/scripts/validate_reusable_workflow_schemas.sh
+++ b/scripts/validate_reusable_workflow_schemas.sh
@@ -30,7 +30,7 @@ validate_add_members_schema() {
   assert_contains "$file" "required: true"
   assert_contains "$file" "python-version:"
   assert_contains "$file" "default: \"3.11\""
-  assert_contains "$file" "app-id:"
+  assert_contains "$file" "app-client-id:"
   assert_contains "$file" "app-private-key:"
   assert_contains "$file" "required: true"
 }


### PR DESCRIPTION
Closes off dependabot PRs defined in #52 and deprecation fix in #34 
Manual intervention needed to cover off codeql bumps as actions were not completing due to misaligned versions

Updates `permission-pull-requests: write` for dependabot PR tracker, as tracking comment additions were returning 403s