### PR TITLE
Fix project identification

### DIFF
--- a/scripts/add_issue_to_project.sh
+++ b/scripts/add_issue_to_project.sh
@@ -50,12 +50,39 @@ NORMALIZED_FIELD_UPDATES=$(echo "$PROJECT_FIELDS_JSON" | jq -c '
   end
 ')
 
-PROJECT_NUMBER=$(gh project list --owner "$PROJECT_OWNER" --format json \
-  | jq -r --arg title "$PROJECT_TITLE" '.. | objects | select(.title? == $title and .number?) | .number' \
-  | head -n1)
+# Resolve project by number first when a numeric value is supplied; otherwise resolve by title.
+if [[ "$PROJECT_TITLE" =~ ^[0-9]+$ ]]; then
+  PROJECT_NUMBER="$PROJECT_TITLE"
+else
+  PROJECTS_JSON=$(gh project list --owner "$PROJECT_OWNER" --limit 1000 --format json)
+
+  PROJECT_NUMBER=$(echo "$PROJECTS_JSON" | jq -r --arg title "$PROJECT_TITLE" '
+    [
+      .. | objects
+      | select(.title? and .number?)
+      | select(.title == $title)
+      | .number
+    ][0] // empty
+  ')
+
+  if [[ -z "$PROJECT_NUMBER" ]]; then
+    # Fallback to whitespace-normalized matching to tolerate accidental spacing drift.
+    PROJECT_NUMBER=$(echo "$PROJECTS_JSON" | jq -r --arg title "$PROJECT_TITLE" '
+      def norm: gsub("[[:space:]]+"; " ") | gsub("^ "; "") | gsub(" $"; "");
+      [
+        .. | objects
+        | select(.title? and .number?)
+        | select((.title | norm) == ($title | norm))
+        | .number
+      ][0] // empty
+    ')
+  fi
+fi
 
 if [[ -z "$PROJECT_NUMBER" ]]; then
   echo "ERROR: project '$PROJECT_TITLE' not found under '$PROJECT_OWNER'."
+  echo "INFO: Ensure the GitHub App token can read organization projects and that the title is exact."
+  echo "INFO: You can also pass a numeric project number as project-title to skip title lookup."
   exit 1
 fi
 


### PR DESCRIPTION
## Issue

The  new`add-new-issues-to-project` workflow failed with:

```
ERROR: project '👩‍💻 Developer Experience Team' not found under 'ministryofjustice'.
Error: Process completed with exit code 1.
```

It failed because the original lookup logic in the script did not reliably find the target project in the API response set.

## Changes

This pull request improves how the `scripts/add_issue_to_project.sh` script resolves the project number from a given project title or number. The main goal is to make the script more robust and user-friendly, especially when handling project titles with varying whitespace or when a numeric project number is provided directly.

**Project resolution improvements:**

* The script now checks if `PROJECT_TITLE` is a numeric value and, if so, uses it directly as the project number, bypassing the title lookup.
* If a project title is provided, the script first attempts an exact match, and if not found, falls back to a whitespace-normalized comparison to handle accidental spacing differences.
* Improved error messaging to guide users on permissions and the option to use a numeric project number directly.